### PR TITLE
bugfix: dont re-export gateway sdk type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,6 @@ import { AllAuctionsResponse, AuctionBidResponse } from './common/auction.types'
 import { AddressMapT } from './mappings/entities';
 
 export {
-    GatewayStatusResponse,
     DomainAttributesResponse,
     DomainDetailsResponse,
     RecordItem,


### PR DESCRIPTION
A consuming package (at least with webpack setup) gives an error complaining that it could not find this type. Removing this seems to fix the issue

![image](https://github.com/radixnameservice/sdk/assets/17203907/b779b3e3-2691-4a65-a9b2-a8e2e61bf2e1)
