### PR TITLE
feat: rns v2 spec

### DIFF
--- a/src/common/domain.types.ts
+++ b/src/common/domain.types.ts
@@ -10,7 +10,6 @@ export interface RootDomainI {
     name: string,
     address: string,
     created_timestamp: number,
-    last_valid_timestamp: number,
     key_image_url: string,
 
 }

--- a/src/requests/address/domains.ts
+++ b/src/requests/address/domains.ts
@@ -171,10 +171,6 @@ function filterSubdomains(
                     return { ...acc, [field.field_name]: +field.value * 1000 };
                 }
 
-                if (field.field_name === 'last_valid_timestamp' && field.kind === 'Enum' && field.variant_name !== 'None' && field.fields[0].kind === 'I64') {
-                    return { ...acc, [field.field_name]: +field.fields[0].value * 1000 };
-                }
-
                 return acc;
 
             }, { id: r.non_fungible_id } as SubDomainI);
@@ -219,10 +215,6 @@ function formatDomainList(
 
                 if (field.field_name === 'created_timestamp' && field.kind === 'I64') {
                     return { ...acc, [field.field_name]: +field.value * 1000 };
-                }
-
-                if (field.field_name === 'last_valid_timestamp' && field.kind === 'Enum' && field.variant_name !== 'None' && field.fields[0].kind === 'I64') {
-                    return { ...acc, [field.field_name]: +field.fields[0].value * 1000 };
                 }
 
                 if (field.kind === 'Enum' && field.field_name === 'address') {
@@ -340,10 +332,6 @@ export async function requestDomainDetails(
 
             if (field.field_name === 'created_timestamp' && field.kind === 'I64') {
                 return { ...acc, [field.field_name]: +field.value * 1000 };
-            }
-
-            if (field.field_name === 'last_valid_timestamp' && field.kind === 'Enum' && field.variant_name !== 'None' && field.fields[0].kind === 'I64') {
-                return { ...acc, [field.field_name]: +field.fields[0].value * 1000 };
             }
 
             if (field.field_name === 'address' && field.kind === 'Enum') {

--- a/src/requests/domain/status.ts
+++ b/src/requests/domain/status.ts
@@ -155,12 +155,6 @@ async function requestDomainProperties(domainName: string, { sdkInstance }: Inst
             throw new Error(domain.message);
 
         if (domain) {
-            if (new Date().getTime() >= domain.last_valid_timestamp) {
-                return {
-                    status: DomainStatus.Unclaimed
-                }
-            }
-
             return {
                 status: DomainStatus.Claimed
             };

--- a/src/tests/e2e/accounts.test.ts
+++ b/src/tests/e2e/accounts.test.ts
@@ -15,7 +15,7 @@ describe('RNS - Verify Domain Owner Accounts', () => {
 
         expect(Array.isArray(ownerDomains)).toBe(true);
         expect(ownerDomains.length).toBeGreaterThan(0);
-        expect(ownerDomains.every(domain => matchObjectTypes<DomainDataI>(domain, ['id', 'name', 'subdomains', 'created_timestamp', 'last_valid_timestamp', 'key_image_url', 'address']))).toBe(true);
+        expect(ownerDomains.every(domain => matchObjectTypes<DomainDataI>(domain, ['id', 'name', 'subdomains', 'created_timestamp', 'key_image_url', 'address']))).toBe(true);
 
     });
 

--- a/src/tests/e2e/details.test.ts
+++ b/src/tests/e2e/details.test.ts
@@ -10,7 +10,7 @@ describe('RNS - Fetch Domain Details', () => {
 
         const details = await rns.getDomainDetails({ domain: 'radixnameservice.xrd' });
 
-        if (!matchObjectTypes<RootDomainI>(details, ['id', 'name', 'address', 'created_timestamp', 'last_valid_timestamp', 'key_image_url'])) {
+        if (!matchObjectTypes<RootDomainI>(details, ['id', 'name', 'address', 'created_timestamp', 'key_image_url'])) {
             throw new Error('Domain object did not match expected schema');
         }
 


### PR DESCRIPTION
- Removed all references to expiration and last valid timestamps.
- Domain status now returns "registered" if KV value returns elapsed "last_valid_timestamp" status.
- Versioned (package.json) for release.