### PR TITLE
feat: user defined pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@radixnameservice/rns-sdk",
-  "version": "3.8.1",
+  "version": "4.0.0",
   "description": "The official toolkit for the Radix Name Service",
   "type": "module",
   "scripts": {

--- a/src/common/domain.types.ts
+++ b/src/common/domain.types.ts
@@ -52,6 +52,5 @@ export interface PaginatedSubdomainsResponseI {
 }
 
 export interface DomainPaginationParamsI {
-    maxResultLength?: number;
     page?: number;
 }

--- a/src/common/domain.types.ts
+++ b/src/common/domain.types.ts
@@ -4,7 +4,6 @@ export interface DomainDataI extends RootDomainI {
 
     price: RawPricePairI;
     subdomains?: SubDomainI[];
-    subdomain_count?: number;
 
 }
 

--- a/src/common/domain.types.ts
+++ b/src/common/domain.types.ts
@@ -4,6 +4,7 @@ export interface DomainDataI extends RootDomainI {
 
     price: RawPricePairI;
     subdomains?: SubDomainI[];
+    subdomains_exist?: boolean;
 
 }
 

--- a/src/common/domain.types.ts
+++ b/src/common/domain.types.ts
@@ -3,7 +3,8 @@ import { RawPricePairI } from "./pricing.types";
 export interface DomainDataI extends RootDomainI {
 
     price: RawPricePairI;
-    subdomains: SubDomainI[];
+    subdomains?: SubDomainI[];
+    subdomain_count?: number;
 
 }
 
@@ -30,4 +31,27 @@ export interface SubDomainI {
     created_timestamp: number;
     key_image_url: string;
 
+}
+
+export interface PaginationInfoI {
+    next_page: number | null;
+    previous_page: number | null;
+    total_count: number;
+    current_page_count: number;
+}
+
+export interface PaginatedDomainsResponseI {
+    domains: DomainDataI[];
+    pagination: PaginationInfoI;
+}
+
+export interface PaginatedSubdomainsResponseI {
+    subdomains: SubDomainI[];
+    pagination: PaginationInfoI;
+    root_domain_id: string;
+}
+
+export interface DomainPaginationParamsI {
+    maxResultLength?: number;
+    page?: number;
 }

--- a/src/common/response.types.ts
+++ b/src/common/response.types.ts
@@ -1,6 +1,6 @@
 import { StateNonFungibleDetailsResponseItem } from "@radixdlt/babylon-gateway-api-sdk";
 import { RawPricePairI } from "./pricing.types";
-import { DomainDataI } from "./domain.types";
+import { DomainDataI, PaginatedDomainsResponseI, PaginatedSubdomainsResponseI } from "./domain.types";
 import { RecordItemI } from "./record.types";
 
 export interface ErrorStackI {
@@ -45,6 +45,10 @@ export type RecordListResponseT = RecordItemI[] | [];
 export type RecordResponseT = RecordItemI | null;
 
 export type DomainListResponseT = DomainDataI[] | [];
+
+export type PaginatedDomainListResponseT = PaginatedDomainsResponseI | [];
+
+export type PaginatedSubdomainListResponseT = PaginatedSubdomainsResponseI | [];
 
 export type CheckAuthenticityResponseT = { isAuthentic: boolean };
 

--- a/src/dispatchers/domain/activation.ts
+++ b/src/dispatchers/domain/activation.ts
@@ -18,10 +18,13 @@ export async function dispatchDomainActivation({
 
     try {
 
+        const subdomainsResponse = await sdkInstance.getSubdomains({ domain: domainDetails.name });
+        const subdomainIds = subdomainsResponse.errors ? [] : subdomainsResponse.data.subdomains.map(subdomain => subdomain.id);
+
         const manifest = await activateDomainManifest({
             sdkInstance,
             rootDomainId: domainDetails.id,
-            subdomainIds: domainDetails.subdomains ? domainDetails.subdomains.map(subdomain => subdomain.id) : [],
+            subdomainIds,
             accountAddress
         });
 

--- a/src/dispatchers/domain/subdomain-deletion.ts
+++ b/src/dispatchers/domain/subdomain-deletion.ts
@@ -20,7 +20,13 @@ export async function dispatchSubdomainDeletion({
 
     try {
 
-        const subdomainDetails = rootDomainDetails.subdomains.find((subdomainItem) => subdomainItem.name === subdomain);
+        const subdomainsResponse = await sdkInstance.getSubdomains({ domain: rootDomainDetails.name });
+        
+        if (subdomainsResponse.errors) {
+            return transactionError(errors.subdomain.generic({ subdomain }));
+        }
+
+        const subdomainDetails = subdomainsResponse.data.subdomains.find((subdomainItem) => subdomainItem.name === subdomain);
 
         if (!subdomainDetails)
             return transactionError(errors.subdomain.doesNotExist({ subdomain }));

--- a/src/dispatchers/domain/transfer.ts
+++ b/src/dispatchers/domain/transfer.ts
@@ -20,6 +20,9 @@ export async function dispatchDomainTransfer({
 
     try {
 
+        const subdomainsResponse = await sdkInstance.getSubdomains({ domain: domainDetails.name });
+        const subdomainIds = subdomainsResponse.errors ? [] : subdomainsResponse.data.subdomains.map(subdomain => subdomain.id);
+
         const manifest = await transferDomainManifest({
             sdkInstance,
             rootDomainId: domainDetails.id,
@@ -29,7 +32,7 @@ export async function dispatchDomainTransfer({
                 deleteRecords: preferences?.deleteRecords ?? false,
                 deleteSubdomains: preferences?.deleteSubdomains ?? false,
             },
-            subdomainIds: domainDetails.subdomains ? domainDetails.subdomains.map(subdomain => subdomain.id) : [],
+            subdomainIds,
         });
 
         const dispatch = await sendTransaction({

--- a/src/index.ts
+++ b/src/index.ts
@@ -276,12 +276,12 @@ export default class RnsSDK {
     }
 
     @requireDependencies('read-only')
-    async getSubdomains({ rootDomainId, pagination }: { rootDomainId: string; pagination?: DomainPaginationParamsI }): Promise<SdkResponseT<PaginatedSubdomainsResponseI>> {
+    async getSubdomains({ domain, pagination }: { domain: string; pagination?: DomainPaginationParamsI }): Promise<SdkResponseT<PaginatedSubdomainsResponseI>> {
 
-        const subdomains = await getSubdomains(rootDomainId, { sdkInstance: this }, pagination);
+        const subdomains = await getSubdomains(domain, { sdkInstance: this }, pagination);
 
         if (subdomains instanceof Error)
-            return retrievalError(errors.domain.generic({ domain: rootDomainId, verbose: subdomains.message }));
+            return retrievalError(errors.domain.generic({ domain, verbose: subdomains.message }));
 
         return retrievalResponse(subdomains);
 
@@ -576,27 +576,3 @@ export default class RnsSDK {
     };
 
 }
-
-(async () => {
-
-    const rns = new RnsSDK({
-        network: 'mainnet'
-    });
-
-    // const attributes = await rns.getDomainAttributes('james2.xrd');
-    // const records = await rns.getRecords('james2.xrd');
-
-    // const resolvedRecord = await rns.resolveRecord({
-    //     domain: 'test-records-present.xrd',
-    //     context: 'funnels',
-    //     directive: 'xrd'
-    //  });
-
-    // const auction = await rns.getAuction('nft.xrd');
-    // console.log(auction);
-
-    const ownerDomains = await rns.getAccountDomains({ accountAddress: 'account_rdx16yte04k8qwdw3l49humul5wpnesfyg2ws8nea8ezceuq90nr506au0', pagination: { page: 2 } });
-
-    console.log(ownerDomains.data);
-
-})();

--- a/src/requests/address/domains.ts
+++ b/src/requests/address/domains.ts
@@ -573,7 +573,7 @@ export async function requestSubDomainDetails(
 
 export async function getSubdomains(
 
-    rootDomainId: string,
+    domain: string,
     { sdkInstance }: InstancePropsI,
     pagination?: DomainPaginationParamsI
 
@@ -581,10 +581,10 @@ export async function getSubdomains(
 
     try {
 
+        const rootDomainId = await domainToNonFungId(domain);
         const maxResults = pagination?.maxResultLength || 25;
         const currentPage = pagination?.page || 1;
 
-        // Get all subdomain IDs for this root domain
         const allSubdomainIds = await fetchSubdomainIds([rootDomainId], { sdkInstance });
 
         if (!allSubdomainIds || allSubdomainIds.length === 0) {
@@ -602,13 +602,11 @@ export async function getSubdomains(
 
         const totalCount = allSubdomainIds.length;
 
-        // Calculate pagination
         const totalPages = Math.ceil(totalCount / maxResults);
         const offset = (currentPage - 1) * maxResults;
 
         const paginatedSubdomainIds = allSubdomainIds.slice(offset, offset + maxResults);
 
-        // Get subdomain data
         const subdomainData = await sdkInstance.state.getNonFungibleData(
             sdkInstance.entities.resources.collections.domains,
             paginatedSubdomainIds
@@ -616,7 +614,6 @@ export async function getSubdomains(
 
         const formattedSubdomains = formatSubdomainList(subdomainData);
 
-        // Calculate next and previous cursors
         const nextCursor = currentPage < totalPages ? currentPage + 1 : null;
         const previousCursor = currentPage > 1 ? currentPage - 1 : null;
 

--- a/src/requests/address/domains.ts
+++ b/src/requests/address/domains.ts
@@ -324,26 +324,6 @@ function formatDomainList(
 
 }
 
-async function getSubdomainCount(
-
-    rootDomainId: string,
-    { sdkInstance }: InstancePropsI
-
-): Promise<number> {
-
-    try {
-
-        const subdomainIds = await fetchSubdomainIds([rootDomainId], { sdkInstance });
-        return subdomainIds?.length || 0;
-
-    } catch (error) {
-
-        logger.error("getSubdomainCount", error);
-        return 0;
-
-    }
-
-}
 
 function supplementDomainList(domains: RootDomainI[], { sdkInstance }: InstancePropsI): DomainDataI[] {
 
@@ -404,25 +384,15 @@ async function fetchPaginatedDomainData(
         const formattedDomains = formatDomainList(domains);
         const supplementedDomains = supplementDomainList(formattedDomains, { sdkInstance });
 
-        const domainsWithSubdomainCounts = await Promise.all(
-            supplementedDomains.map(async (domain) => {
-                const subdomainCount = await getSubdomainCount(domain.id, { sdkInstance });
-                return {
-                    ...domain,
-                    subdomain_count: subdomainCount
-                };
-            })
-        );
-
         const paginationInfo: PaginationInfoI = {
             next_page: nextCursor,
             previous_page: previousCursor,
             total_count: totalCount,
-            current_page_count: domainsWithSubdomainCounts.length
+            current_page_count: supplementedDomains.length
         };
 
         return {
-            domains: domainsWithSubdomainCounts,
+            domains: supplementedDomains,
             pagination: paginationInfo
         };
 

--- a/src/tests/e2e/accounts.test.ts
+++ b/src/tests/e2e/accounts.test.ts
@@ -13,9 +13,9 @@ describe('RNS - Verify Domain Owner Accounts', () => {
             throw new Error('Domain list fetch failed');
         }
 
-        expect(Array.isArray(ownerDomains.data)).toBe(true);
-        expect(ownerDomains.data.length).toBeGreaterThan(0);
-        expect(ownerDomains.data.every(domain => matchObjectTypes<DomainDataI>(domain, ['id', 'name', 'subdomains', 'created_timestamp', 'key_image_url', 'address']))).toBe(true);
+        expect(Array.isArray(ownerDomains.data.domains)).toBe(true);
+        expect(ownerDomains.data.domains.length).toBeGreaterThan(0);
+        expect(ownerDomains.data.domains.every(domain => matchObjectTypes<DomainDataI>(domain, ['id', 'name', 'created_timestamp', 'key_image_url', 'address']))).toBe(true);
 
     });
 

--- a/src/tests/e2e/activation.test.ts
+++ b/src/tests/e2e/activation.test.ts
@@ -59,6 +59,9 @@ describe('RNS - Activate Domain', () => {
 
         const rns = new RnsSDK({ network: 'stokenet', rdt: dAppToolkit });
 
+        const subdomainsResponse = await rns.getSubdomains({ domain: "radixnameservice.xrd" });
+        const actualSubdomainIds = subdomainsResponse.errors ? [] : subdomainsResponse.data.subdomains.map(sub => sub.id);
+
         const activate = await rns.activateDomain({
             domain: "radixnameservice.xrd",
             accountAddress: mocks.userDetails.accountAddress
@@ -105,7 +108,7 @@ describe('RNS - Activate Domain', () => {
                 true
                 true
                 Array<NonFungibleLocalId>(
-                    ${anticipated.domain.subdomainIds.map(id => `NonFungibleLocalId("${id}")`).join(', ')}
+                    ${actualSubdomainIds.map(id => `NonFungibleLocalId("${id}")`).join(', ')}
                 )
                 Proof("requested_proof")
                 Enum<0u8>();

--- a/src/tests/e2e/records.test.ts
+++ b/src/tests/e2e/records.test.ts
@@ -1,6 +1,8 @@
+import RnsSDK, { ResolvedRecordResponseT } from '../..';
+
 import { RadixDappToolkit } from '@radixdlt/radix-dapp-toolkit';
 import { RadixNetwork } from '@radixdlt/babylon-gateway-api-sdk';
-import RnsSDK, { ResolvedRecordResponseT } from '../..';
+
 import { matchObjectTypes, normaliseManifest } from '../utils';
 import { RecordDocketI, RecordItemI } from '../../common/record.types';
 import { buildFungibleProofs, buildNonFungibleProofs } from '../../utils/proof.utils';

--- a/src/tests/e2e/subdomains.test.ts
+++ b/src/tests/e2e/subdomains.test.ts
@@ -1,17 +1,21 @@
 
-import RnsSDK, { DomainDataI } from '../..';
+import RnsSDK, { DomainDataI, PaginatedSubdomainsResponseI } from '../..';
 
 import { RadixDappToolkit } from '@radixdlt/radix-dapp-toolkit';
 import { RadixNetwork } from '@radixdlt/babylon-gateway-api-sdk';
 
-import { normaliseManifest } from '../utils';
+import { matchObjectTypes, normaliseManifest } from '../utils';
 import { deriveRootDomain, normaliseDomain } from '../../utils/domain.utils';
 
 const mocks = {
-    rootDomain: {
-        id: "[52e57ee0bdd7681786e15a0dabb7bdc4]"
+    domains: {
+        withSubdomains: 'subdomains.xrd',
+        withoutSubdomains: 'no-subdomains.xrd'
     },
-    subdomain: `test-subdomain.radixnameservice.xrd`,
+    rootDomain: {
+        id: "[cb1368c760c7b1a126be405c4eb3457d]"
+    },
+    subdomain: `test.subdomains.xrd`,
     userDetails: {
         accountAddress: 'account_tdx_2_129076yrjr5k4lumhp3fl2r88xt3eqgxwed6saplvf2ezz5szrhet8k'
     },
@@ -96,6 +100,79 @@ describe('RNS - Create Subdomain', () => {
 
 });
 
+describe('RNS - Get Subdomain', () => {
+
+    it('should return paginated subdomains for domain with subdomains', async () => {
+
+        const subdomainsResponse = await rns.getSubdomains({
+            domain: mocks.domains.withSubdomains
+        });
+
+        expect(subdomainsResponse.errors).toBeUndefined();
+        expect(subdomainsResponse.data).toBeDefined();
+        expect(matchObjectTypes<PaginatedSubdomainsResponseI>(subdomainsResponse.data, ['subdomains', 'pagination'])).toBe(true);
+
+        expect(subdomainsResponse.data.pagination).toBeDefined();
+        expect(matchObjectTypes(subdomainsResponse.data.pagination, ['next_page', 'previous_page', 'total_count', 'current_page_count'])).toBe(true);
+
+        expect(Array.isArray(subdomainsResponse.data.subdomains)).toBe(true);
+
+        if (subdomainsResponse.data.subdomains.length > 0) {
+            expect(subdomainsResponse.data.subdomains.every(subdomain =>
+                matchObjectTypes(subdomain, ['id', 'name', 'created_timestamp', 'key_image_url'])
+            )).toBe(true);
+        }
+    });
+
+    it('should indicate subdomain existence in domain details', async () => {
+
+        const domainDetails = await rns.getDomainDetails({
+            domain: mocks.domains.withSubdomains
+        });
+
+        const domainData = domainDetails.data as DomainDataI;
+        expect(typeof domainData.subdomains_exist).toBe('boolean');
+
+    });
+
+    it('should return empty subdomains array for domain without subdomains', async () => {
+        const subdomainsResponse = await rns.getSubdomains({
+            domain: mocks.domains.withoutSubdomains
+        });
+
+        if (!subdomainsResponse.errors) {
+            expect(subdomainsResponse.data.subdomains).toBeDefined();
+            expect(Array.isArray(subdomainsResponse.data.subdomains)).toBe(true);
+            expect(subdomainsResponse.data.subdomains.length).toBe(0);
+            expect(subdomainsResponse.data.pagination.total_count).toBe(0);
+        }
+    });
+
+    it('should handle pagination parameters correctly', async () => {
+        
+        const page1Response = await rns.getSubdomains({
+            domain: mocks.domains.withSubdomains,
+            pagination: { page: 1 }
+        });
+
+        expect(page1Response.data.pagination.previous_page).toBeNull();
+
+        if (page1Response.data.pagination.total_count > 100) {
+            expect(page1Response.data.pagination.next_page).toBe(2);
+
+            const page2Response = await rns.getSubdomains({
+                domain: mocks.domains.withSubdomains,
+                pagination: { page: 2 }
+            });
+
+            if (!page2Response.errors) {
+                expect(page2Response.data.pagination.previous_page).toBe(1);
+            }
+        }
+    });
+
+});
+
 describe('RNS - Delete Subdomain', () => {
 
     afterEach(() => {
@@ -111,13 +188,13 @@ describe('RNS - Delete Subdomain', () => {
         if (rootDomainDetails.errors) {
             throw new Error('Root domain details could not be obtained');
         }
-        
+
         const subdomainsResponse = await rns.getSubdomains({ domain: deriveRootDomain(mocks.subdomain) });
-        
+
         if (subdomainsResponse.errors) {
             throw new Error('Subdomains could not be obtained');
         }
-        
+
         const subdomainDetails = subdomainsResponse.data.subdomains.find((subdomain) => subdomain.name === normalisedSubDomain);
 
         if (!subdomainDetails) {

--- a/src/tests/e2e/subdomains.test.ts
+++ b/src/tests/e2e/subdomains.test.ts
@@ -111,9 +111,14 @@ describe('RNS - Delete Subdomain', () => {
         if (rootDomainDetails.errors) {
             throw new Error('Root domain details could not be obtained');
         }
-
-        const subdomainData = rootDomainDetails.data as DomainDataI;
-        const subdomainDetails = subdomainData.subdomains.find((subdomain) => subdomain.name === normalisedSubDomain);
+        
+        const subdomainsResponse = await rns.getSubdomains({ domain: deriveRootDomain(mocks.subdomain) });
+        
+        if (subdomainsResponse.errors) {
+            throw new Error('Subdomains could not be obtained');
+        }
+        
+        const subdomainDetails = subdomainsResponse.data.subdomains.find((subdomain) => subdomain.name === normalisedSubDomain);
 
         if (!subdomainDetails) {
             throw new Error('Subdomain details could not be obtained');

--- a/src/tests/e2e/transfers.test.ts
+++ b/src/tests/e2e/transfers.test.ts
@@ -59,6 +59,9 @@ describe('RNS - Transfer Domain', () => {
 
         const rootDomainData = rootDomainDetails.data as DomainDataI;
 
+        const subdomainsResponse = await rns.getSubdomains({ domain: mocks.domain.name });
+        const actualSubdomainIds = subdomainsResponse.errors ? [] : subdomainsResponse.data.subdomains.map(sub => sub.id);
+
         const transferDomain = await rns.transferDomain({
             domain: mocks.domain.name,
             fromAddress: mocks.fromAddress,
@@ -93,7 +96,7 @@ describe('RNS - Transfer Domain', () => {
                 ${mocks.preferences.deleteSubdomains}
                 ${mocks.preferences.deleteRecords}
                 Array<NonFungibleLocalId>(
-                    ${rootDomainData.subdomains.map(subdomain => `NonFungibleLocalId("${subdomain.id}")`).join(', ')}
+                    ${actualSubdomainIds.map(id => `NonFungibleLocalId("${id}")`).join(', ')}
                 )
                 Proof("requested_proof")
                 Enum<0u8>();


### PR DESCRIPTION
This update provides more reliable subdomain operations by removing dependency on inconsistent auto-inclusion behavior. Performance is improved by only fetching subdomains when explicitly needed rather than always including them. The new implementation adds proper pagination support for large domain collections, making it easier to work with accounts that own many domains. Additionally, domain operations that affect subdomains now have improved accuracy since they fetch and include actual subdomain data in transaction manifests.

⚠️ **Breaking Changes**

- getAccountDomains() now returns domains nested under data.domains instead of directly in data.
- Response now includes pagination metadata object with next_page, previous_page, total_count, and current_page_count.
- Domain subdomains are no longer automatically included in getDomainDetails() responses.
- Subdomain access now requires separate getSubdomains() API call for reliable results.
- DomainDataI interface updated with optional subdomains property and new subdomains_exist flag.

**Functionalities**

- Feat: Added separate getSubdomains() API with proper pagination support.
- Feat: Enhanced getAccountDomains() to return structured response with pagination metadata.
- Feat: Implemented dynamic subdomain fetching for domain operations.
- Feat: Added comprehensive test coverage for subdomain querying functionality.

